### PR TITLE
Initialize SparkContext first to avoid timeout problem on YARN

### DIFF
--- a/examples/mnist_mlp_spark.py
+++ b/examples/mnist_mlp_spark.py
@@ -18,6 +18,10 @@ batch_size = 64
 nb_classes = 10
 nb_epoch = 3
 
+# Create Spark context
+conf = SparkConf().setAppName('Mnist_Spark_MLP')  # .setMaster('local[8]')
+sc = SparkContext(conf=conf)
+
 # Load data
 (X_train, y_train), (X_test, y_test) = mnist.load_data()
 
@@ -47,10 +51,6 @@ model.add(Activation('softmax'))
 # Compile model
 sgd = SGD(lr=0.1)
 model.compile(loss='categorical_crossentropy', optimizer=sgd)
-
-# Create Spark context
-conf = SparkConf().setAppName('Mnist_Spark_MLP')  # .setMaster('local[8]')
-sc = SparkContext(conf=conf)
 
 # Build RDD from numpy features and labels
 rdd = to_simple_rdd(sc, X_train, Y_train)


### PR DESCRIPTION
I ran this example with Spark on YARN. Because `mnist.load_data()` needs more time to download data, it causes timeout problem when initializing YARN containers. By moving SparkContext initialization before downloading the data we can fix this problem.