### PR TITLE
Batch update frequency error

### DIFF
--- a/elephas/spark_model.py
+++ b/elephas/spark_model.py
@@ -285,7 +285,7 @@ class AsynchronousSparkWorker(object):
 
         nb_epoch = self.train_config['nb_epoch']
         batch_size = self.train_config.get('batch_size')
-        nb_train_sample = len(x_train[0])
+        nb_train_sample = x_train.shape[0]
         nb_batch = int(np.ceil(nb_train_sample/float(batch_size)))
         index_array = np.arange(nb_train_sample)
         batches = [(i*batch_size, min(nb_train_sample, (i+1)*batch_size)) for i in range(0, nb_batch)]


### PR DESCRIPTION
I was trying to execute the training with update frequency set to
"batch" instead of epoch, when i got this error:

> "/anaconda2/lib/python2.7/site-packages/elephas/spark_model.py",
> line 311, in train
>     X = slice_X(x_train, batch_ids)
>   File
> "/anaconda2/lib/python2.7/site-packages/Keras-1.2.2-py2.7.egg/keras/engine/training.py",
> line 306, in slice_X
>     return X[start]
> IndexError: index 132 is out of bounds for axis 0 with size 132
>         at
> org.apache.spark.api.python.PythonRDD$$anon$1.read(PythonRDD.scala:138)
>         at
> org.apache.spark.api.python.PythonRDD$$anon$1.<init>(PythonRDD.scala:179)
>         at
> org.apache.spark.api.python.PythonRDD.compute(PythonRDD.scala:97)
>         at
> org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:297)
>         at org.apache.spark.rdd.RDD.iterator(RDD.scala:264)
>         at
> org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:66)
>         at org.apache.spark.scheduler.Task.run(Task.scala:88)
>         at
> org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:214)
>         at
> java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
>         at
> java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
>         at java.lang.Thread.run(Thread.java:745)
>

I think it may be caused by the variable i edited in the
pull(nb_train_sample)