### PR TITLE
minor doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ from elephas import optimizers as elephas_optimizers
 
 adagrad = elephas_optimizers.Adagrad()
 spark_model = SparkModel(sc,model, optimizer=adagrad, frequency='epoch', mode='asynchronous', num_workers=2)
-spark_model.train(rdd, nb_epoch=20, batch_size=32, verbose=0, validation_split=0.1, num_workers=8)
+spark_model.train(rdd, nb_epoch=20, batch_size=32, verbose=0, validation_split=0.1)
 ```
 
 - Run your script using spark-submit


### PR DESCRIPTION
`spark_model` is an instance of `elephas.spark_model.SparkModel`.
According to the [source code](https://github.com/maxpumperla/elephas/blob/9a394d7f7486dbf5ceefd121447c01b3c44c941e/elephas/spark_model.py#L188), `SparkModel.train` doesn't have argument `num_workers`.