### PR TITLE
fix path to import keyword-only for Spark 2.2

### DIFF
--- a/elephas/ml_model.py
+++ b/elephas/ml_model.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function
 import numpy as np
 
 from pyspark.ml.param.shared import HasInputCol, HasOutputCol, HasFeaturesCol, HasLabelCol
-from pyspark.ml.util import keyword_only
+from pyspark import keyword_only
 from pyspark.sql import Row
 from pyspark.ml import Estimator, Model
 from pyspark.sql.types import StringType, DoubleType, StructField


### PR DESCRIPTION
from pyspark.ml.util import keyword_only
in ml_model.py is not working, perhaps spark has changed the location of keayboard_only in Spark 2.2.

If we change this to: from pyspark import keyword_only
then it works.
