### PR TITLE
Fixed number of parameters passed to SparkWorker

### DIFF
--- a/elephas/spark_model.py
+++ b/elephas/spark_model.py
@@ -216,7 +216,10 @@ class SparkModel(object):
         elif self.mode == 'synchronous':
             init = self.master_network.get_weights()
             parameters = self.spark_context.broadcast(init)
-            worker = SparkWorker(yaml, parameters, train_config)
+            worker = SparkWorker(
+                yaml, parameters, train_config, 
+                self.master_optimizer, self.master_loss, self.master_metrics, self.custom_objects
+            )
             deltas = rdd.mapPartitions(worker.train).collect()
             new_parameters = self.master_network.get_weights()
             for delta in deltas:


### PR DESCRIPTION
When training a SparkModel in "synchronous" mode, the following error is thrown
`TypeError: __init__() takes exactly 8 arguments (4 given)`
I added to the parameters passed to SparkWorker's constructor in order to make "synchronous" mode work.