### PR TITLE
Fixed number of epochs model is fitted (Issue #77)

### DIFF
--- a/elephas/spark_model.py
+++ b/elephas/spark_model.py
@@ -304,6 +304,7 @@ class AsynchronousSparkWorker(object):
                 self.train_config['nb_epochs'] = 1
                 if x_train.shape[0] > batch_size:
                     model.fit(x_train, y_train, **self.train_config)
+                self.train_config['nb_epochs'] = nb_epoch
                 weights_after_training = model.get_weights()
                 deltas = subtract_params(weights_before_training, weights_after_training)
                 put_deltas_to_server(deltas, self.master_url)

--- a/elephas/spark_model.py
+++ b/elephas/spark_model.py
@@ -301,10 +301,10 @@ class AsynchronousSparkWorker(object):
                 weights_before_training = get_server_weights(self.master_url)
                 model.set_weights(weights_before_training)
                 self.train_config['epochs'] = 1
-                self.train_config['nb_epochs'] = 1
+                self.train_config['nb_epoch'] = 1
                 if x_train.shape[0] > batch_size:
                     model.fit(x_train, y_train, **self.train_config)
-                self.train_config['nb_epochs'] = nb_epoch
+                self.train_config['nb_epoch'] = nb_epoch
                 weights_after_training = model.get_weights()
                 deltas = subtract_params(weights_before_training, weights_after_training)
                 put_deltas_to_server(deltas, self.master_url)

--- a/elephas/spark_model.py
+++ b/elephas/spark_model.py
@@ -301,6 +301,7 @@ class AsynchronousSparkWorker(object):
                 weights_before_training = get_server_weights(self.master_url)
                 model.set_weights(weights_before_training)
                 self.train_config['epochs'] = 1
+                self.train_config['nb_epochs'] = 1
                 if x_train.shape[0] > batch_size:
                     model.fit(x_train, y_train, **self.train_config)
                 weights_after_training = model.get_weights()


### PR DESCRIPTION
Issue #77 explains that a "model is fitted more than nb_epoch" times under "asynchronous" mode.
When examining Keras's source code,
```
        # Legacy support
        if 'nb_epoch' in kwargs:
            warnings.warn('The `nb_epoch` argument in `fit` '
                          'has been renamed `epochs`.')
            epochs = kwargs.pop('nb_epoch')
```
 it overrides whatever value is found in `epochs`. I set `nb_epochs` to one as well, so this problem is avoided.