### PR TITLE
vector.array does not work with sparse vectors. vector.toArray() work…

### DIFF
--- a/elephas/mllib/adapter.py
+++ b/elephas/mllib/adapter.py
@@ -23,7 +23,7 @@ def to_matrix(np_array):
 def from_vector(vector):
     """Convert MLlib Vector to numpy array
     """
-    return vector.array
+    return vector.toArray()
 
 
 def to_vector(np_array):


### PR DESCRIPTION
vector.array does not work with sparse vectors. 
vector.toArray() works with both vector types