### PR TITLE
Add support for predicting class probabilities

### DIFF
--- a/elephas/ml/params.py
+++ b/elephas/ml/params.py
@@ -243,3 +243,18 @@ class HasCustomObjects(Params):
 
     def get_custom_objects(self):
         return self.getOrDefault(self.custom_objects)
+
+
+class HasPredictClasses(Params):
+    def __init__(self):
+        super(HasPredictClasses, self).__init__()
+        self.predict_classes = Param(self, "predict_classes", "Flag to predict class or probability in classification "
+                                                              "problems")
+        self._setDefault(predict_classes=True)
+
+    def set_predict_classes(self, predict_classes):
+        self._paramMap[self.predict_classes] = predict_classes
+        return self
+
+    def get_predict_classes(self):
+        return self.getOrDefault(self.predict_classes)

--- a/elephas/ml_model.py
+++ b/elephas/ml_model.py
@@ -7,10 +7,10 @@ import h5py
 import json
 
 from pyspark.ml.param.shared import HasOutputCol, HasFeaturesCol, HasLabelCol
-from pyspark import keyword_only, RDD
+from pyspark import keyword_only
 from pyspark.ml import Estimator, Model
 from pyspark.sql import DataFrame
-from pyspark.sql.types import StringType, DoubleType, StructField, ArrayType
+from pyspark.sql.types import DoubleType, StructField, ArrayType
 
 from tensorflow.keras.models import model_from_yaml
 from tensorflow.keras.optimizers import get as get_optimizer

--- a/elephas/utils/model_utils.py
+++ b/elephas/utils/model_utils.py
@@ -55,8 +55,9 @@ class LossModelTypeMapper(Singleton):
 
 
 def determine_predict_function(model: tensorflow.keras.models.Model,
-                               model_type: ModelType):
-    if model_type == ModelType.CLASSIFICATION:
+                               model_type: ModelType,
+                               predict_classes: bool = True):
+    if model_type == ModelType.CLASSIFICATION and predict_classes:
         if isinstance(model, tensorflow.keras.models.Sequential):
             predict_function = model.predict_classes
         else:

--- a/elephas/utils/warnings.py
+++ b/elephas/utils/warnings.py
@@ -1,0 +1,2 @@
+class ElephasWarning(Warning):
+    """Custom warning class for any Elephas issues"""

--- a/tests/test_ml_model.py
+++ b/tests/test_ml_model.py
@@ -276,10 +276,10 @@ def test_predict_classes_probability(spark_context, classification_model, mnist_
     pipeline = Pipeline(stages=[estimator])
     fitted_pipeline = pipeline.fit(df)
 
-    # Evaluate Spark model by evaluating the underlying model
-    prediction = fitted_pipeline.transform(test_df)
-    pnl = prediction.select("label", "prediction")
-    pnl.show(100)
+    results = fitted_pipeline.transform(test_df)
+    # we should have an array of 10 elements in the prediction column, since we have 10 classes
+    # and therefore 10 probabilities
+    assert len(results.take(1)[0].prediction) == 10
 
 
 def test_set_predict_classes_regression_warning(spark_context, regression_model):

--- a/tests/test_ml_model.py
+++ b/tests/test_ml_model.py
@@ -10,6 +10,8 @@ from elephas.ml.adapter import to_data_frame
 from pyspark.mllib.evaluation import MulticlassMetrics, RegressionMetrics
 from pyspark.ml import Pipeline
 
+from elephas.utils.warnings import ElephasWarning
+
 
 def test_serialization_transformer(classification_model):
     transformer = ElephasTransformer()
@@ -242,4 +244,48 @@ def test_custom_objects(spark_context, boston_housing_dataset):
     prediction = fitted_pipeline.transform(test_df)
 
 
+def test_predict_classes_probability(spark_context, classification_model, mnist_data):
+    batch_size = 64
+    nb_classes = 10
+    epochs = 1
 
+    x_train, y_train, x_test, y_test = mnist_data
+    x_train = x_train[:1000]
+    y_train = y_train[:1000]
+    df = to_data_frame(spark_context, x_train, y_train, categorical=True)
+    test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
+
+    sgd = optimizers.SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+    sgd_conf = optimizers.serialize(sgd)
+
+    # Initialize Spark ML Estimator
+    estimator = ElephasEstimator()
+    estimator.set_keras_model_config(classification_model.to_yaml())
+    estimator.set_optimizer_config(sgd_conf)
+    estimator.set_mode("synchronous")
+    estimator.set_loss("categorical_crossentropy")
+    estimator.set_metrics(['acc'])
+    estimator.set_predict_classes(False)
+    estimator.set_epochs(epochs)
+    estimator.set_batch_size(batch_size)
+    estimator.set_validation_split(0.1)
+    estimator.set_categorical_labels(True)
+    estimator.set_nb_classes(nb_classes)
+
+    # Fitting a model returns a Transformer
+    pipeline = Pipeline(stages=[estimator])
+    fitted_pipeline = pipeline.fit(df)
+
+    # Evaluate Spark model by evaluating the underlying model
+    prediction = fitted_pipeline.transform(test_df)
+    pnl = prediction.select("label", "prediction")
+    pnl.show(100)
+
+
+def test_set_predict_classes_regression_warning(spark_context, regression_model):
+    with pytest.warns(ElephasWarning):
+        estimator = ElephasEstimator()
+        estimator.set_loss("mae")
+        estimator.set_metrics(['mae'])
+        estimator.set_categorical_labels(False)
+        estimator.set_predict_classes(True)


### PR DESCRIPTION
Add support for class probability prediction when utilizing `ElephasTransformer`. This addresses https://github.com/maxpumperla/elephas/issues/174 and https://github.com/maxpumperla/elephas/issues/137. This also resulted in some simplification of the logic in the `_transform` method, as there were some unnecessary field type conversions.