### PR TITLE
Remove Custom Predict Logic

### DIFF
--- a/elephas/ml/params.py
+++ b/elephas/ml/params.py
@@ -243,18 +243,3 @@ class HasCustomObjects(Params):
 
     def get_custom_objects(self):
         return self.getOrDefault(self.custom_objects)
-
-
-class HasPredictClasses(Params):
-    def __init__(self):
-        super(HasPredictClasses, self).__init__()
-        self.predict_classes = Param(self, "predict_classes", "Flag to predict class or probability in classification "
-                                                              "problems")
-        self._setDefault(predict_classes=True)
-
-    def set_predict_classes(self, predict_classes):
-        self._paramMap[self.predict_classes] = predict_classes
-        return self
-
-    def get_predict_classes(self):
-        return self.getOrDefault(self.predict_classes)

--- a/elephas/parameter/client.py
+++ b/elephas/parameter/client.py
@@ -5,10 +5,7 @@ import socket
 import pickle
 
 
-try:
-    import urllib.request as urllib2
-except ImportError:
-    import urllib2
+import urllib.request as urllib2
 
 from ..utils.sockets import determine_master, send, receive
 

--- a/tests/test_hyperparam.py
+++ b/tests/test_hyperparam.py
@@ -1,7 +1,6 @@
 from hyperopt import STATUS_OK
 from hyperas.distributions import choice, uniform
-import six.moves.cPickle as pickle
-
+import pickle
 from elephas.hyperparam import HyperParamModel
 
 


### PR DESCRIPTION
- remove custom handling for prediction - just utilize `model.predict` for regression and classification
- add `argmax` function, which should enable users to replicate the original `predict` behavior in classification problems
